### PR TITLE
fix spacing on otherwise unmodified project code

### DIFF
--- a/src/helper_functions.h
+++ b/src/helper_functions.h
@@ -23,29 +23,29 @@ const double M_PI = 3.14159265358979323846;
  * Struct representing one position/control measurement.
  */
 struct control_s {
-	
-	double velocity;	// Velocity [m/s]
-	double yawrate;		// Yaw rate [rad/s]
+  
+  double velocity;  // Velocity [m/s]
+  double yawrate;    // Yaw rate [rad/s]
 };
 
 /*
  * Struct representing one ground truth position.
  */
 struct ground_truth {
-	
-	double x;		// Global vehicle x position [m]
-	double y;		// Global vehicle y position
-	double theta;	// Global vehicle yaw [rad]
+  
+  double x;    // Global vehicle x position [m]
+  double y;    // Global vehicle y position
+  double theta;  // Global vehicle yaw [rad]
 };
 
 /*
  * Struct representing one landmark observation measurement.
  */
 struct LandmarkObs {
-	
-	int id;				// Id of matching landmark in the map.
-	double x;			// Local (vehicle coordinates) x position of landmark observation [m]
-	double y;			// Local (vehicle coordinates) y position of landmark observation [m]
+  
+  int id;        // Id of matching landmark in the map.
+  double x;      // Local (vehicle coordinates) x position of landmark observation [m]
+  double y;      // Local (vehicle coordinates) y position of landmark observation [m]
 };
 
 /*
@@ -55,19 +55,19 @@ struct LandmarkObs {
  * @output Euclidean distance between two 2D points
  */
 inline double dist(double x1, double y1, double x2, double y2) {
-	return sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
+  return sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
 }
 
 inline double * getError(double gt_x, double gt_y, double gt_theta, double pf_x, double pf_y, double pf_theta) {
-	static double error[3];
-	error[0] = fabs(pf_x - gt_x);
-	error[1] = fabs(pf_y - gt_y);
-	error[2] = fabs(pf_theta - gt_theta);
-	error[2] = fmod(error[2], 2.0 * M_PI);
-	if (error[2] > M_PI) {
-		error[2] = 2.0 * M_PI - error[2];
-	}
-	return error;
+  static double error[3];
+  error[0] = fabs(pf_x - gt_x);
+  error[1] = fabs(pf_y - gt_y);
+  error[2] = fabs(pf_theta - gt_theta);
+  error[2] = fmod(error[2], 2.0 * M_PI);
+  if (error[2] > M_PI) {
+    error[2] = 2.0 * M_PI - error[2];
+  }
+  return error;
 }
 
 /* Reads map data from a file.
@@ -76,42 +76,42 @@ inline double * getError(double gt_x, double gt_y, double gt_theta, double pf_x,
  */
 inline bool read_map_data(std::string filename, Map& map) {
 
-	// Get file of map:
-	std::ifstream in_file_map(filename.c_str(),std::ifstream::in);
-	// Return if we can't open the file.
-	if (!in_file_map) {
-		return false;
-	}
-	
-	// Declare single line of map file:
-	std::string line_map;
+  // Get file of map:
+  std::ifstream in_file_map(filename.c_str(),std::ifstream::in);
+  // Return if we can't open the file.
+  if (!in_file_map) {
+    return false;
+  }
+  
+  // Declare single line of map file:
+  std::string line_map;
 
-	// Run over each single line:
-	while(getline(in_file_map, line_map)){
+  // Run over each single line:
+  while(getline(in_file_map, line_map)){
 
-		std::istringstream iss_map(line_map);
+    std::istringstream iss_map(line_map);
 
-		// Declare landmark values and ID:
-		float landmark_x_f, landmark_y_f;
-		int id_i;
+    // Declare landmark values and ID:
+    float landmark_x_f, landmark_y_f;
+    int id_i;
 
-		// Read data from current line to values::
-		iss_map >> landmark_x_f;
-		iss_map >> landmark_y_f;
-		iss_map >> id_i;
+    // Read data from current line to values::
+    iss_map >> landmark_x_f;
+    iss_map >> landmark_y_f;
+    iss_map >> id_i;
 
-		// Declare single_landmark:
-		Map::single_landmark_s single_landmark_temp;
+    // Declare single_landmark:
+    Map::single_landmark_s single_landmark_temp;
 
-		// Set values
-		single_landmark_temp.id_i = id_i;
-		single_landmark_temp.x_f  = landmark_x_f;
-		single_landmark_temp.y_f  = landmark_y_f;
+    // Set values
+    single_landmark_temp.id_i = id_i;
+    single_landmark_temp.x_f  = landmark_x_f;
+    single_landmark_temp.y_f  = landmark_y_f;
 
-		// Add to landmark list of map:
-		map.landmark_list.push_back(single_landmark_temp);
-	}
-	return true;
+    // Add to landmark list of map:
+    map.landmark_list.push_back(single_landmark_temp);
+  }
+  return true;
 }
 
 /* Reads control data from a file.
@@ -120,41 +120,41 @@ inline bool read_map_data(std::string filename, Map& map) {
  */
 inline bool read_control_data(std::string filename, std::vector<control_s>& position_meas) {
 
-	// Get file of position measurements:
-	std::ifstream in_file_pos(filename.c_str(),std::ifstream::in);
-	// Return if we can't open the file.
-	if (!in_file_pos) {
-		return false;
-	}
+  // Get file of position measurements:
+  std::ifstream in_file_pos(filename.c_str(),std::ifstream::in);
+  // Return if we can't open the file.
+  if (!in_file_pos) {
+    return false;
+  }
 
-	// Declare single line of position measurement file:
-	std::string line_pos;
+  // Declare single line of position measurement file:
+  std::string line_pos;
 
-	// Run over each single line:
-	while(getline(in_file_pos, line_pos)){
+  // Run over each single line:
+  while(getline(in_file_pos, line_pos)){
 
-		std::istringstream iss_pos(line_pos);
+    std::istringstream iss_pos(line_pos);
 
-		// Declare position values:
-		double velocity, yawrate;
+    // Declare position values:
+    double velocity, yawrate;
 
-		// Declare single control measurement:
-		control_s meas;
+    // Declare single control measurement:
+    control_s meas;
 
-		//read data from line to values:
+    //read data from line to values:
 
-		iss_pos >> velocity;
-		iss_pos >> yawrate;
+    iss_pos >> velocity;
+    iss_pos >> yawrate;
 
-		
-		// Set values
-		meas.velocity = velocity;
-		meas.yawrate = yawrate;
+    
+    // Set values
+    meas.velocity = velocity;
+    meas.yawrate = yawrate;
 
-		// Add to list of control measurements:
-		position_meas.push_back(meas);
-	}
-	return true;
+    // Add to list of control measurements:
+    position_meas.push_back(meas);
+  }
+  return true;
 }
 
 /* Reads ground truth data from a file.
@@ -163,41 +163,41 @@ inline bool read_control_data(std::string filename, std::vector<control_s>& posi
  */
 inline bool read_gt_data(std::string filename, std::vector<ground_truth>& gt) {
 
-	// Get file of position measurements:
-	std::ifstream in_file_pos(filename.c_str(),std::ifstream::in);
-	// Return if we can't open the file.
-	if (!in_file_pos) {
-		return false;
-	}
+  // Get file of position measurements:
+  std::ifstream in_file_pos(filename.c_str(),std::ifstream::in);
+  // Return if we can't open the file.
+  if (!in_file_pos) {
+    return false;
+  }
 
-	// Declare single line of position measurement file:
-	std::string line_pos;
+  // Declare single line of position measurement file:
+  std::string line_pos;
 
-	// Run over each single line:
-	while(getline(in_file_pos, line_pos)){
+  // Run over each single line:
+  while(getline(in_file_pos, line_pos)){
 
-		std::istringstream iss_pos(line_pos);
+    std::istringstream iss_pos(line_pos);
 
-		// Declare position values:
-		double x, y, azimuth;
+    // Declare position values:
+    double x, y, azimuth;
 
-		// Declare single ground truth:
-		ground_truth single_gt; 
+    // Declare single ground truth:
+    ground_truth single_gt; 
 
-		//read data from line to values:
-		iss_pos >> x;
-		iss_pos >> y;
-		iss_pos >> azimuth;
+    //read data from line to values:
+    iss_pos >> x;
+    iss_pos >> y;
+    iss_pos >> azimuth;
 
-		// Set values
-		single_gt.x = x;
-		single_gt.y = y;
-		single_gt.theta = azimuth;
+    // Set values
+    single_gt.x = x;
+    single_gt.y = y;
+    single_gt.theta = azimuth;
 
-		// Add to list of control measurements and ground truth:
-		gt.push_back(single_gt);
-	}
-	return true;
+    // Add to list of control measurements and ground truth:
+    gt.push_back(single_gt);
+  }
+  return true;
 }
 
 /* Reads landmark observation data from a file.
@@ -206,39 +206,39 @@ inline bool read_gt_data(std::string filename, std::vector<ground_truth>& gt) {
  */
 inline bool read_landmark_data(std::string filename, std::vector<LandmarkObs>& observations) {
 
-	// Get file of landmark measurements:
-	std::ifstream in_file_obs(filename.c_str(),std::ifstream::in);
-	// Return if we can't open the file.
-	if (!in_file_obs) {
-		return false;
-	}
+  // Get file of landmark measurements:
+  std::ifstream in_file_obs(filename.c_str(),std::ifstream::in);
+  // Return if we can't open the file.
+  if (!in_file_obs) {
+    return false;
+  }
 
-	// Declare single line of landmark measurement file:
-	std::string line_obs;
+  // Declare single line of landmark measurement file:
+  std::string line_obs;
 
-	// Run over each single line:
-	while(getline(in_file_obs, line_obs)){
+  // Run over each single line:
+  while(getline(in_file_obs, line_obs)){
 
-		std::istringstream iss_obs(line_obs);
+    std::istringstream iss_obs(line_obs);
 
-		// Declare position values:
-		double local_x, local_y;
+    // Declare position values:
+    double local_x, local_y;
 
-		//read data from line to values:
-		iss_obs >> local_x;
-		iss_obs >> local_y;
+    //read data from line to values:
+    iss_obs >> local_x;
+    iss_obs >> local_y;
 
-		// Declare single landmark measurement:
-		LandmarkObs meas;
+    // Declare single landmark measurement:
+    LandmarkObs meas;
 
-		// Set values
-		meas.x = local_x;
-		meas.y = local_y;
+    // Set values
+    meas.x = local_x;
+    meas.y = local_y;
 
-		// Add to list of control measurements:
-		observations.push_back(meas);
-	}
-	return true;
+    // Add to list of control measurements:
+    observations.push_back(meas);
+  }
+  return true;
 }
 
 #endif /* HELPER_FUNCTIONS_H_ */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,15 +18,13 @@ std::string hasData(std::string s) {
   auto b2 = s.find_first_of("]");
   if (found_null != std::string::npos) {
     return "";
-  }
-  else if (b1 != std::string::npos && b2 != std::string::npos) {
+  } else if (b1 != std::string::npos && b2 != std::string::npos) {
     return s.substr(b1, b2 - b1 + 1);
   }
   return "";
 }
 
-int main()
-{
+int main() {
   uWS::Hub h;
 
   //Set up parameters here
@@ -39,96 +37,89 @@ int main()
   // Read map data
   Map map;
   if (!read_map_data("../data/map_data.txt", map)) {
-	  cout << "Error: Could not open map file" << endl;
-	  return -1;
+    cout << "Error: Could not open map file" << endl;
+    return -1;
   }
 
   // Create particle filter
   ParticleFilter pf;
 
-  h.onMessage([&pf,&map,&delta_t,&sensor_range,&sigma_pos,&sigma_landmark](uWS::WebSocket<uWS::SERVER> ws, char *data, size_t length, uWS::OpCode opCode) {
+  h.onMessage([&pf,&map,&delta_t,&sensor_range,&sigma_pos,&sigma_landmark](uWS::WebSocket<uWS::SERVER> ws,
+              char *data, size_t length, uWS::OpCode opCode) {
     // "42" at the start of the message means there's a websocket message event.
     // The 4 signifies a websocket message
     // The 2 signifies a websocket event
 
-    if (length && length > 2 && data[0] == '4' && data[1] == '2')
-    {
-
+    if (length && length > 2 && data[0] == '4' && data[1] == '2') {
       auto s = hasData(std::string(data));
       if (s != "") {
-      	
-      	
         auto j = json::parse(s);
         std::string event = j[0].get<std::string>();
         
         if (event == "telemetry") {
           // j[1] is the data JSON object
 
-
           if (!pf.initialized()) {
+            // Sense noisy position data from the simulator
+            double sense_x = std::stod(j[1]["sense_x"].get<std::string>());
+            double sense_y = std::stod(j[1]["sense_y"].get<std::string>());
+            double sense_theta = std::stod(j[1]["sense_theta"].get<std::string>());
 
-          	// Sense noisy position data from the simulator
-			double sense_x = std::stod(j[1]["sense_x"].get<std::string>());
-			double sense_y = std::stod(j[1]["sense_y"].get<std::string>());
-			double sense_theta = std::stod(j[1]["sense_theta"].get<std::string>());
+            pf.init(sense_x, sense_y, sense_theta, sigma_pos);
+          } else {
+            // Predict the vehicle's next state from previous (noiseless control) data.
+            double previous_velocity = std::stod(j[1]["previous_velocity"].get<std::string>());
+            double previous_yawrate = std::stod(j[1]["previous_yawrate"].get<std::string>());
 
-			pf.init(sense_x, sense_y, sense_theta, sigma_pos);
-		  }
-		  else {
-			// Predict the vehicle's next state from previous (noiseless control) data.
-		  	double previous_velocity = std::stod(j[1]["previous_velocity"].get<std::string>());
-			double previous_yawrate = std::stod(j[1]["previous_yawrate"].get<std::string>());
+            pf.prediction(delta_t, sigma_pos, previous_velocity, previous_yawrate);
+          }
 
-			pf.prediction(delta_t, sigma_pos, previous_velocity, previous_yawrate);
-		  }
+          // receive noisy observation data from the simulator
+          // sense_observations in JSON format [{obs_x,obs_y},{obs_x,obs_y},...{obs_x,obs_y}]
+          vector<LandmarkObs> noisy_observations;
+          string sense_observations_x = j[1]["sense_observations_x"];
+          string sense_observations_y = j[1]["sense_observations_y"];
 
-		  // receive noisy observation data from the simulator
-		  // sense_observations in JSON format [{obs_x,obs_y},{obs_x,obs_y},...{obs_x,obs_y}]
-		  	vector<LandmarkObs> noisy_observations;
-		  	string sense_observations_x = j[1]["sense_observations_x"];
-		  	string sense_observations_y = j[1]["sense_observations_y"];
+          std::vector<float> x_sense;
+          std::istringstream iss_x(sense_observations_x);
 
-		  	std::vector<float> x_sense;
-  			std::istringstream iss_x(sense_observations_x);
+          std::copy(std::istream_iterator<float>(iss_x),
+          std::istream_iterator<float>(),
+          std::back_inserter(x_sense));
 
-  			std::copy(std::istream_iterator<float>(iss_x),
-        	std::istream_iterator<float>(),
-        	std::back_inserter(x_sense));
+          std::vector<float> y_sense;
+          std::istringstream iss_y(sense_observations_y);
 
-        	std::vector<float> y_sense;
-  			std::istringstream iss_y(sense_observations_y);
+          std::copy(std::istream_iterator<float>(iss_y),
+          std::istream_iterator<float>(),
+          std::back_inserter(y_sense));
 
-  			std::copy(std::istream_iterator<float>(iss_y),
-        	std::istream_iterator<float>(),
-        	std::back_inserter(y_sense));
+          for (int i = 0; i < x_sense.size(); i++) {
+            LandmarkObs obs;
+            obs.x = x_sense[i];
+            obs.y = y_sense[i];
+            noisy_observations.push_back(obs);
+          }
 
-        	for(int i = 0; i < x_sense.size(); i++)
-        	{
-        		LandmarkObs obs;
-        		obs.x = x_sense[i];
-				obs.y = y_sense[i];
-				noisy_observations.push_back(obs);
-        	}
+          // Update the weights and resample
+          pf.updateWeights(sensor_range, sigma_landmark, noisy_observations, map);
+          pf.resample();
 
-		  // Update the weights and resample
-		  pf.updateWeights(sensor_range, sigma_landmark, noisy_observations, map);
-		  pf.resample();
-
-		  // Calculate and output the average weighted error of the particle filter over all time steps so far.
-		  vector<Particle> particles = pf.particles;
-		  int num_particles = particles.size();
-		  double highest_weight = -1.0;
-		  Particle best_particle;
-		  double weight_sum = 0.0;
-		  for (int i = 0; i < num_particles; ++i) {
-			if (particles[i].weight > highest_weight) {
-				highest_weight = particles[i].weight;
-				best_particle = particles[i];
-			}
-			weight_sum += particles[i].weight;
-		  }
-		  cout << "highest w " << highest_weight << endl;
-		  cout << "average w " << weight_sum/num_particles << endl;
+          // Calculate and output the average weighted error of the particle filter over all time steps so far.
+          vector<Particle> particles = pf.particles;
+          int num_particles = particles.size();
+          double highest_weight = -1.0;
+          Particle best_particle;
+          double weight_sum = 0.0;
+          for (int i = 0; i < num_particles; ++i) {
+            if (particles[i].weight > highest_weight) {
+              highest_weight = particles[i].weight;
+              best_particle = particles[i];
+            }
+            weight_sum += particles[i].weight;
+          }
+          cout << "highest w " << highest_weight << endl;
+          cout << "average w " << weight_sum/num_particles << endl;
 
           json msgJson;
           msgJson["best_particle_x"] = best_particle.x;
@@ -143,26 +134,22 @@ int main()
           auto msg = "42[\"best_particle\"," + msgJson.dump() + "]";
           // std::cout << msg << std::endl;
           ws.send(msg.data(), msg.length(), uWS::OpCode::TEXT);
-	  
+      
         }
       } else {
         std::string msg = "42[\"manual\",{}]";
         ws.send(msg.data(), msg.length(), uWS::OpCode::TEXT);
       }
     }
-
   });
 
   // We don't need this since we're not using HTTP but if it's removed the program
   // doesn't compile :-(
   h.onHttpRequest([](uWS::HttpResponse *res, uWS::HttpRequest req, char *data, size_t, size_t) {
     const std::string s = "<h1>Hello world!</h1>";
-    if (req.getUrl().valueLength == 1)
-    {
+    if (req.getUrl().valueLength == 1) {
       res->end(s.data(), s.length());
-    }
-    else
-    {
+    } else {
       // i guess this should be done more gracefully?
       res->end(nullptr, 0);
     }
@@ -178,101 +165,11 @@ int main()
   });
 
   int port = 4567;
-  if (h.listen(port))
-  {
+  if (h.listen(port)) {
     std::cout << "Listening to port " << port << std::endl;
-  }
-  else
-  {
+  } else {
     std::cerr << "Failed to listen to port" << std::endl;
     return -1;
   }
   h.run();
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/map.h
+++ b/src/map.h
@@ -10,18 +10,16 @@
 
 class Map {
 public:
-	
-	struct single_landmark_s{
 
-		int id_i ; // Landmark ID
-		float x_f; // Landmark x-position in the map (global coordinates)
-		float y_f; // Landmark y-position in the map (global coordinates)
-	};
+  struct single_landmark_s{
 
-	std::vector<single_landmark_s> landmark_list ; // List of landmarks in the map
+    int id_i ; // Landmark ID
+    float x_f; // Landmark x-position in the map (global coordinates)
+    float y_f; // Landmark y-position in the map (global coordinates)
+  };
+
+  std::vector<single_landmark_s> landmark_list ; // List of landmarks in the map
 
 };
-
-
 
 #endif /* MAP_H_ */

--- a/src/particle_filter.h
+++ b/src/particle_filter.h
@@ -12,111 +12,103 @@
 #include "helper_functions.h"
 
 struct Particle {
-
-	int id;
-	double x;
-	double y;
-	double theta;
-	double weight;
-	std::vector<int> associations;
-	std::vector<double> sense_x;
-	std::vector<double> sense_y;
+  int id;
+  double x;
+  double y;
+  double theta;
+  double weight;
+  std::vector<int> associations;
+  std::vector<double> sense_x;
+  std::vector<double> sense_y;
 };
-
-
 
 class ParticleFilter {
-	
-	// Number of particles to draw
-	int num_particles; 
-	
-	
-	
-	// Flag, if filter is initialized
-	bool is_initialized;
-	
-	// Vector of weights of all particles
-	std::vector<double> weights;
-	
+  
+  // Number of particles to draw
+  int num_particles; 
+
+  // Flag, if filter is initialized
+  bool is_initialized;
+
+  // Vector of weights of all particles
+  std::vector<double> weights;
+
 public:
-	
-	// Set of current particles
-	std::vector<Particle> particles;
 
-	// Constructor
-	// @param num_particles Number of particles
-	ParticleFilter() : num_particles(0), is_initialized(false) {}
+  // Set of current particles
+  std::vector<Particle> particles;
 
-	// Destructor
-	~ParticleFilter() {}
+  // Constructor
+  // @param num_particles Number of particles
+  ParticleFilter() : num_particles(0), is_initialized(false) {}
 
-	/**
-	 * init Initializes particle filter by initializing particles to Gaussian
-	 *   distribution around first position and all the weights to 1.
-	 * @param x Initial x position [m] (simulated estimate from GPS)
-	 * @param y Initial y position [m]
-	 * @param theta Initial orientation [rad]
-	 * @param std[] Array of dimension 3 [standard deviation of x [m], standard deviation of y [m]
-	 *   standard deviation of yaw [rad]]
-	 */
-	void init(double x, double y, double theta, double std[]);
+  // Destructor
+  ~ParticleFilter() {}
 
-	/**
-	 * prediction Predicts the state for the next time step
-	 *   using the process model.
-	 * @param delta_t Time between time step t and t+1 in measurements [s]
-	 * @param std_pos[] Array of dimension 3 [standard deviation of x [m], standard deviation of y [m]
-	 *   standard deviation of yaw [rad]]
-	 * @param velocity Velocity of car from t to t+1 [m/s]
-	 * @param yaw_rate Yaw rate of car from t to t+1 [rad/s]
-	 */
-	void prediction(double delta_t, double std_pos[], double velocity, double yaw_rate);
-	
-	/**
-	 * dataAssociation Finds which observations correspond to which landmarks (likely by using
-	 *   a nearest-neighbors data association).
-	 * @param predicted Vector of predicted landmark observations
-	 * @param observations Vector of landmark observations
-	 */
-	void dataAssociation(std::vector<LandmarkObs> predicted, std::vector<LandmarkObs>& observations);
-	
-	/**
-	 * updateWeights Updates the weights for each particle based on the likelihood of the 
-	 *   observed measurements. 
-	 * @param sensor_range Range [m] of sensor
-	 * @param std_landmark[] Array of dimension 2 [Landmark measurement uncertainty [x [m], y [m]]]
-	 * @param observations Vector of landmark observations
-	 * @param map Map class containing map landmarks
-	 */
-	void updateWeights(double sensor_range, double std_landmark[], const std::vector<LandmarkObs> &observations,
-			const Map &map_landmarks);
-	
-	/**
-	 * resample Resamples from the updated set of particles to form
-	 *   the new set of particles.
-	 */
-	void resample();
+  /**
+   * init Initializes particle filter by initializing particles to Gaussian
+   *   distribution around first position and all the weights to 1.
+   * @param x Initial x position [m] (simulated estimate from GPS)
+   * @param y Initial y position [m]
+   * @param theta Initial orientation [rad]
+   * @param std[] Array of dimension 3 [standard deviation of x [m], standard deviation of y [m]
+   *   standard deviation of yaw [rad]]
+   */
+  void init(double x, double y, double theta, double std[]);
 
-	/*
-	 * Set a particles list of associations, along with the associations calculated world x,y coordinates
-	 * This can be a very useful debugging tool to make sure transformations are correct and assocations correctly connected
-	 */
-	Particle SetAssociations(Particle& particle, const std::vector<int>& associations,
-		                     const std::vector<double>& sense_x, const std::vector<double>& sense_y);
+  /**
+   * prediction Predicts the state for the next time step
+   *   using the process model.
+   * @param delta_t Time between time step t and t+1 in measurements [s]
+   * @param std_pos[] Array of dimension 3 [standard deviation of x [m], standard deviation of y [m]
+   *   standard deviation of yaw [rad]]
+   * @param velocity Velocity of car from t to t+1 [m/s]
+   * @param yaw_rate Yaw rate of car from t to t+1 [rad/s]
+   */
+  void prediction(double delta_t, double std_pos[], double velocity, double yaw_rate);
 
-	
-	std::string getAssociations(Particle best);
-	std::string getSenseX(Particle best);
-	std::string getSenseY(Particle best);
+  /**
+   * dataAssociation Finds which observations correspond to which landmarks (likely by using
+   *   a nearest-neighbors data association).
+   * @param predicted Vector of predicted landmark observations
+   * @param observations Vector of landmark observations
+   */
+  void dataAssociation(std::vector<LandmarkObs> predicted, std::vector<LandmarkObs>& observations);
 
-	/**
-	* initialized Returns whether particle filter is initialized yet or not.
-	*/
-	const bool initialized() const {
-		return is_initialized;
-	}
+  /**
+   * updateWeights Updates the weights for each particle based on the likelihood of the 
+   *   observed measurements. 
+   * @param sensor_range Range [m] of sensor
+   * @param std_landmark[] Array of dimension 2 [Landmark measurement uncertainty [x [m], y [m]]]
+   * @param observations Vector of landmark observations
+   * @param map Map class containing map landmarks
+   */
+  void updateWeights(double sensor_range, double std_landmark[], const std::vector<LandmarkObs> &observations,
+      const Map &map_landmarks);
+
+  /**
+   * resample Resamples from the updated set of particles to form
+   *   the new set of particles.
+   */
+  void resample();
+
+  /*
+   * Set a particles list of associations, along with the associations calculated world x,y coordinates
+   * This can be a very useful debugging tool to make sure transformations are correct and assocations correctly connected
+   */
+  Particle SetAssociations(Particle& particle, const std::vector<int>& associations,
+                          const std::vector<double>& sense_x, const std::vector<double>& sense_y);
+
+  std::string getAssociations(Particle best);
+  std::string getSenseX(Particle best);
+  std::string getSenseY(Particle best);
+
+  /**
+  * initialized Returns whether particle filter is initialized yet or not.
+  */
+  const bool initialized() const {
+    return is_initialized;
+  }
 };
-
-
 
 #endif /* PARTICLE_FILTER_H_ */


### PR DESCRIPTION
Mix of tabs and spaces throughout the repo now normalized to 2-space tab width.

`main.cpp` was particularly bad with no indentation in some locations, fixed so it's now readable.